### PR TITLE
Add Firestore CRUD operations for tasks

### DIFF
--- a/lib/tasks_firestore.ts
+++ b/lib/tasks_firestore.ts
@@ -1,0 +1,45 @@
+import { getFirestore, collection, doc, setDoc, getDocs, updateDoc, deleteDoc, Timestamp } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
+
+// Initialize Firestore
+const db = getFirestore();
+const auth = getAuth();
+
+// Function to create a task
+export const createTask = async (userId: string, title: string, description: string, importance: boolean, urgency: boolean, dueDate?: Timestamp) => {
+  const taskRef = doc(collection(db, `users/${userId}/tasks`));
+  const taskData = {
+    title,
+    description,
+    importance,
+    urgency,
+    completed: false,
+    dueDate: dueDate || null,
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
+  };
+  await setDoc(taskRef, taskData);
+  return taskRef.id;
+};
+
+// Function to read tasks
+export const readTasks = async (userId: string) => {
+  const tasksSnapshot = await getDocs(collection(db, `users/${userId}/tasks`));
+  const tasksList = tasksSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+  return tasksList;
+};
+
+// Function to update a task
+export const updateTask = async (userId: string, taskId: string, updatedData: Partial<{ title: string; description: string; importance: boolean; urgency: boolean; completed: boolean; dueDate: Timestamp }>) => {
+  const taskRef = doc(db, `users/${userId}/tasks`, taskId);
+  await updateDoc(taskRef, {
+    ...updatedData,
+    updatedAt: Timestamp.now(),
+  });
+};
+
+// Function to delete a task
+export const deleteTask = async (userId: string, taskId: string) => {
+  const taskRef = doc(db, `users/${userId}/tasks`, taskId);
+  await deleteDoc(taskRef);
+};


### PR DESCRIPTION
Add CRUD functions for tasks subcollection in Firestore.

* **lib/tasks_firestore.ts**: 
  - Add function to create a task in the `tasks` subcollection for a user.
  - Add function to read tasks from the `tasks` subcollection for a user.
  - Add function to update a task in the `tasks` subcollection for a user.
  - Add function to delete a task from the `tasks` subcollection for a user.

* **app/tasks/page.tsx**:
  - Import CRUD functions from `lib/tasks_firestore.ts`.
  - Use `useEffect` to fetch tasks when the user is authenticated.
  - Add `fetchTasks` function to read tasks and format them into task lists.
  - Modify `addNewTask` function to create a new task in Firestore.
  - Modify `removeTask` function to delete a task from Firestore.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/00YellowLemon/PRODYAI/pull/2?shareId=275bf920-875b-479d-af43-f2c92f5674f0).