### PR TITLE
Add reflection questions card section to reflections page

### DIFF
--- a/lib/reflectionQuestions_firestore.ts
+++ b/lib/reflectionQuestions_firestore.ts
@@ -36,3 +36,37 @@ export const deleteReflectionQuestion = async (userId: string, reflectionQuestio
   const reflectionQuestionRef = doc(db, `users/${userId}/reflectionQuestions`, reflectionQuestionId);
   await deleteDoc(reflectionQuestionRef);
 };
+
+// Function to create a reflection question
+export const createReflectionQuestion = async (userId: string, question: string) => {
+  const reflectionQuestionRef = doc(collection(db, `users/${userId}/reflectionQuestions`));
+  const reflectionQuestionData = {
+    question,
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
+  };
+  await setDoc(reflectionQuestionRef, reflectionQuestionData);
+  return reflectionQuestionRef.id;
+};
+
+// Function to read reflection questions
+export const readReflectionQuestions = async (userId: string) => {
+  const reflectionQuestionsSnapshot = await getDocs(collection(db, `users/${userId}/reflectionQuestions`));
+  const reflectionQuestionsList = reflectionQuestionsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+  return reflectionQuestionsList;
+};
+
+// Function to update a reflection question
+export const updateReflectionQuestion = async (userId: string, reflectionQuestionId: string, question: string) => {
+  const reflectionQuestionRef = doc(db, `users/${userId}/reflectionQuestions`, reflectionQuestionId);
+  await updateDoc(reflectionQuestionRef, {
+    question,
+    updatedAt: Timestamp.now(),
+  });
+};
+
+// Function to delete a reflection question
+export const deleteReflectionQuestion = async (userId: string, reflectionQuestionId: string) => {
+  const reflectionQuestionRef = doc(db, `users/${userId}/reflectionQuestions`, reflectionQuestionId);
+  await deleteDoc(reflectionQuestionRef);
+};


### PR DESCRIPTION
Add a card section for reflection questions on the reflections page.

* **Reflection Questions Management**
  - Add state management for reflection questions in `app/reflections/page.tsx`.
  - Implement functions to add and delete reflection questions.
  - Fetch and display reflection questions from Firestore.
  - Add input field and button to add new reflection questions.
  - Add delete button for each reflection question.

* **Firestore Integration**
  - Add functions to create, read, update, and delete reflection questions in `lib/reflectionQuestions_firestore.ts`.

* **UI Design**
  - Style the card section and buttons using modern Apple AI design principles.
  - Update the reflections page layout to include the new card section for reflection questions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/00YellowLemon/PRODYAI/pull/8?shareId=fb21f67e-f579-4794-b3f7-3c990ac4ad7a).